### PR TITLE
Fix handling of incorrect number of arguments, typos

### DIFF
--- a/src/cmd_add.rs
+++ b/src/cmd_add.rs
@@ -16,7 +16,7 @@ pub fn cmd_add(opts: &Options, prefix: &path::Path, enc_params: &transform::Encr
     match add_entry(prefix, path::Path::new(relative_path), opts.args[1].as_str(), opts.force, enc_params){
         Ok(_) => {},
         Err(e) => {
-            println!("An error occured while adding the entry: {}", e);
+            println!("An error occurred while adding the entry: {}", e);
             return;
         },
     }

--- a/src/cmd_add.rs
+++ b/src/cmd_add.rs
@@ -5,7 +5,7 @@ use std::path;
 
 pub fn cmd_add(opts: &Options, prefix: &path::Path, enc_params: &transform::EncryptionParams) {
     if opts.args.len() != 2 {
-        println!("Too many arguments. Want: 'path_new, content'  Got: {}", opts.args.len());
+        println!("Incorrect number of arguments. Want: 'path_new, content'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_copy.rs
+++ b/src/cmd_copy.rs
@@ -33,7 +33,7 @@ pub fn cmd_copy(opts: &Options, prefix: &path::Path , enc_params: &transform::En
             Some(p) => {
                 match fs::create_dir_all(p){
                     Ok(_) => {},
-                        Err(e) => {println!("An error occured while creating the needed directories: {}", e);
+                        Err(e) => {println!("An error occurred while creating the needed directories: {}", e);
                         return;
                     },
                 }
@@ -44,7 +44,7 @@ pub fn cmd_copy(opts: &Options, prefix: &path::Path , enc_params: &transform::En
         match fs::copy(full_path_old, full_path_new){
             Ok(_) => {},
             Err(e) => {
-                println!("An error occured while copying to new location: {}", e);
+                println!("An error occurred while copying to new location: {}", e);
                 return;
             },
         };

--- a/src/cmd_copy.rs
+++ b/src/cmd_copy.rs
@@ -6,7 +6,7 @@ use std::fs;
 
 pub fn cmd_copy(opts: &Options, prefix: &path::Path , enc_params: &transform::EncryptionParams) {
     if opts.args.len() != 2 {
-        println!("Too many arguments. Want: 'old_path, new_path'  Got: {}", opts.args.len());
+        println!("Incorrect number of arguments. Want: 'old_path, new_path'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_generate.rs
+++ b/src/cmd_generate.rs
@@ -28,7 +28,7 @@ pub fn cmd_generate(opts: &Options, prefix: &path::Path , enc_params: &transform
     match add_entry(prefix, path::Path::new(relative_path), passwd.as_str(), opts.force, enc_params) {
         Ok(_) => {},
         Err(e) => {
-            println!("An error occured while adding the entry: {}", e);
+            println!("An error occurred while adding the entry: {}", e);
             return;
         },
     }

--- a/src/cmd_generate.rs
+++ b/src/cmd_generate.rs
@@ -5,14 +5,14 @@ use crate::generate;
 use std::path;
 
 pub fn cmd_generate(opts: &Options, prefix: &path::Path , enc_params: &transform::EncryptionParams) {
-    if opts.args.len() > 2 {
-        println!("Too many arguments. Want: 'path, [length]'  Got: {}", opts.args.len());
+    if opts.args.len() > 2 || opts.args.len() < 1 {
+        println!("Incorrect number of arguments. Want: 'path, [length]'  Got: {}", opts.args.len());
         return;
     }
 
     let relative_path = prepare_entry_path(opts.args[0].as_str());
     
-    let passwd = if opts.args.len() >= 2 {
+    let passwd = if opts.args.len() == 2 {
         let length = match opts.args[1].trim().parse() {
             Ok(i) => i,
             Err(e) => {

--- a/src/cmd_list.rs
+++ b/src/cmd_list.rs
@@ -32,7 +32,7 @@ pub fn cmd_list_tree(opts: &Options, prefix: &path::Path , enc_params: &transfor
     let tree = match get_tree_from_path(full_path, is_root, enc_params){
         Ok(t) => t,
         Err(err) => {
-            println!("An error occured while listing entries: {}", err);
+            println!("An error occurred while listing entries: {}", err);
             return;
         },
     };

--- a/src/cmd_list.rs
+++ b/src/cmd_list.rs
@@ -7,8 +7,8 @@ use std::path;
 
 
 pub fn cmd_list_tree(opts: &Options, prefix: &path::Path , enc_params: &transform::EncryptionParams) {
-    if opts.args.len() > 1 {
-        println!("Too many arguments. Want: 'path_to_dir'  Got: {}", opts.args.len());
+    if opts.args.len() < 1 {
+        println!("Too many arguments. Want: '[path_to_dir]'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_move.rs
+++ b/src/cmd_move.rs
@@ -6,7 +6,7 @@ use std::fs;
 
 pub fn cmd_move(opts: &Options, prefix: &path::Path , enc_params: &transform::EncryptionParams) {
     if opts.args.len() != 2 {
-        println!("Too many arguments. Want: 'old_path, new_path'  Got: {}", opts.args.len());
+        println!("Incorrect number of arguments. Want: 'old_path, new_path'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_move.rs
+++ b/src/cmd_move.rs
@@ -28,6 +28,6 @@ pub fn cmd_move(opts: &Options, prefix: &path::Path , enc_params: &transform::En
 
     match fs::rename(full_path_old, full_path_new) {
         Ok(_) => {},
-        Err(e) => println!("An error occured while moving: {}", e),
+        Err(e) => println!("An error occurred while moving: {}", e),
     }
 }

--- a/src/cmd_remove.rs
+++ b/src/cmd_remove.rs
@@ -6,7 +6,7 @@ use std::fs;
 
 pub fn cmd_remove(opts: &Options, prefix: &path::Path , enc_params: &transform::EncryptionParams) {
     if opts.args.len() != 1 {
-        println!("Too many arguments. Want: 'path'  Got: {}", opts.args.len());
+        println!("Incorrect number of arguments. Want: 'path'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_remove.rs
+++ b/src/cmd_remove.rs
@@ -20,7 +20,7 @@ pub fn cmd_remove(opts: &Options, prefix: &path::Path , enc_params: &transform::
         match fs::remove_file(full_path) {
             Ok(_) => {},
             Err(e) => {
-                println!("An error occured while removing: {}", e);
+                println!("An error occurred while removing: {}", e);
                 return;
             },
         }
@@ -30,7 +30,7 @@ pub fn cmd_remove(opts: &Options, prefix: &path::Path , enc_params: &transform::
                 match fs::remove_dir_all(full_path) {
                     Ok(_) => {},
                     Err(e) => {
-                        println!("An error occured while removing: {}", e);
+                        println!("An error occurred while removing: {}", e);
                         return;
                     },
                 }

--- a/src/cmd_search.rs
+++ b/src/cmd_search.rs
@@ -72,7 +72,7 @@ pub fn cmd_search(opts: &Options, prefix: &path::Path, enc_params: &transform::E
     let entries = match get_all_entries_in_path(trans_path_dir){
         Ok(vec) => vec,
         Err(err) => {
-            println!("An error occured while listing entries: {}", err);
+            println!("An error occurred while listing entries: {}", err);
             return;
         },
     };

--- a/src/cmd_search.rs
+++ b/src/cmd_search.rs
@@ -5,7 +5,7 @@ use std::path;
 
 pub fn cmd_search_fuzzy (opts: &Options, prefix: &path::Path, enc_params: &transform::EncryptionParams) {
     if opts.args.len() > 1 {
-        println!("Too many arguments. Want: 'pattern'  Got: {}", opts.args.len());
+        println!("Too many arguments. Want: '[pattern]'  Got: {}", opts.args.len());
         return;
     }
 
@@ -32,7 +32,7 @@ pub fn cmd_search_fuzzy (opts: &Options, prefix: &path::Path, enc_params: &trans
 
 pub fn cmd_search(opts: &Options, prefix: &path::Path, enc_params: &transform::EncryptionParams) {
     if opts.args.len() > 1 {
-        println!("Too many arguments. Want: 'pattern'  Got: {}", opts.args.len());
+        println!("Too many arguments. Want: '[pattern]'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_show.rs
+++ b/src/cmd_show.rs
@@ -6,7 +6,7 @@ use std::path;
 
 pub fn cmd_show(opts: &Options, prefix: &path::Path, enc_params: &transform::EncryptionParams) {
     if opts.args.len() != 1 {
-        println!("Too many arguments. Want: 'path_to_entry'  Got: {}", opts.args.len());
+        println!("Incorrect number of arguments. Want: 'path_to_entry'  Got: {}", opts.args.len());
         return;
     }
 

--- a/src/cmd_show.rs
+++ b/src/cmd_show.rs
@@ -14,7 +14,7 @@ pub fn cmd_show(opts: &Options, prefix: &path::Path, enc_params: &transform::Enc
     let mut content = match show_entry(prefix, path::Path::new(relative_path), enc_params) {
         Ok(c) => c,
         Err(_) => {
-            //entry doesnt exist. Search for it instead
+            //entry doesn't exist. Search for it instead
             cmd_search(opts, prefix, enc_params);
             return;
         },

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -7,7 +7,7 @@ pub fn generate_passwd(length: usize) -> String {
     let mut vbuf = vec![0u8;length];
     let buf = vbuf.as_mut_slice();
 
-    f.read_exact(buf).expect("Couldnt read from /dev/urandom");
+    f.read_exact(buf).expect("Couldn't read from /dev/urandom");
 
     let passwd = base64::encode_config(buf, base64::URL_SAFE_NO_PAD);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
 
         ap.refer(&mut options.interactive)
             .add_option(&["--interactiveoff", "-i"], StoreFalse,
-            "Dont ask for key if not found in argument/SPAKRPASS_KEY");
+            "Don't ask for key if not found in argument/SPAKRPASS_KEY");
 
          ap.refer(&mut options.show_tree)
             .add_option(&["--treeoff", "-t"], StoreFalse,
@@ -97,7 +97,7 @@ fn main() {
 
         ap.refer(&mut options.line)
             .add_option(&["--line", "-l"], Store,
-            "Specify which line of  multiline file you want to show. If set to -1 all lines will be printed. Default is line 0.");
+            "Specify which line of multiline file you want to show. If set to -1 all lines will be printed. Default is line 0.");
 
         ap.refer(&mut options.key)
             .add_option(&["--key", "-k"], Store,
@@ -130,7 +130,7 @@ fn main() {
 
     if options.key == "" {
         if !options.interactive {
-            println!("No key given and interactive mode deactived");
+            println!("No key given and interactive mode deactivated");
             return;
         }
         if options.verbose {

--- a/src/util.rs
+++ b/src/util.rs
@@ -177,7 +177,7 @@ pub fn get_tree_from_path(p: &path::Path, is_clear: bool, enc_params: &transform
 
     let it = match fs::read_dir(p) {
         Ok(iter) => iter,
-        Err(_) => return Err("Couldnt read directory".to_owned()),
+        Err(_) => return Err("Couldn't read directory".to_owned()),
     };
 
     let mut result = Vec::new();
@@ -214,7 +214,7 @@ pub fn get_tree_from_path(p: &path::Path, is_clear: bool, enc_params: &transform
 pub fn get_all_entries_in_path(p: &path::Path) -> Result<Vec<(String,bool)>, String> {
     let it = match fs::read_dir(p) {
         Ok(iter) => iter,
-        Err(_) => return Err("Couldnt read directory".to_owned()),
+        Err(_) => return Err("Couldn't read directory".to_owned()),
     };
 
     let mut result = Vec::new();
@@ -249,7 +249,7 @@ pub fn add_entry(prefix : &path::Path, p: &path::Path, content: &str, overwrite:
     };
 
     if exists && !overwrite {
-        let mut err = "Entry exists already: ".to_owned();
+        let mut err = "Entry already exists: ".to_owned();
         err.push_str(p.to_str().unwrap());
         return Err(err.to_owned())
     }else{
@@ -257,7 +257,7 @@ pub fn add_entry(prefix : &path::Path, p: &path::Path, content: &str, overwrite:
         match fs::create_dir_all(full_path_dir) {
             Ok(_) => {},
             Err(_) => {
-                return Err("An error occured while creating necessary parent directories".to_owned());
+                return Err("An error occurred while creating necessary parent directories".to_owned());
             }
         }
     }
@@ -266,7 +266,7 @@ pub fn add_entry(prefix : &path::Path, p: &path::Path, content: &str, overwrite:
     match fs::write(full_path, trans_content) {
         Ok(_) => {},
         Err(_) => {
-            return Err("An error occured while writing the content to the file".to_owned());
+            return Err("An error occurred while writing the content to the file".to_owned());
         }
     }
 
@@ -293,7 +293,7 @@ pub fn show_entry(prefix: &path::Path, p: &path::Path, enc_params: &transform::E
     let res = match fs::read(full_path) {
         Ok(r) => r,
         Err(_) => {
-            return Err("An error occured while reading the entry from the file".to_owned());
+            return Err("An error occurred while reading the entry from the file".to_owned());
         }
     };
 


### PR DESCRIPTION
Tiny, mostly cosmetic things I noticed when first using sparkpass:
Arguments are marked [optional] in error messages when applicable.
Changed "Too many arguments" to "Incorrect number of arguments" when applicable.
Fixed a bunch of typos.
Also two commands where zero arguments used to crash the program are now fixed